### PR TITLE
Fix write_hello

### DIFF
--- a/hello.py
+++ b/hello.py
@@ -3,8 +3,8 @@ import sys
 from functools import partial
 
 
-def write_hello(file=sys.stdout):
-    print = partial(builtins.print, file=file)
+def write_hello(file=None):
+    print = partial(builtins.print, file=file if file else sys.stdout)
 
     print("Hello")
 


### PR DESCRIPTION
This makes `test_write_hello` pass. The other failing tests are superfluous.

```
py37 installed: attrs==19.3.0,importlib-metadata==1.0.0,more-itertools==8.0.0,packaging==19.2,pluggy==0.13.1,py==1.8.0,pyparsing==2.4.5,pytest==5.3.1,six==1.13.0,wcwidth==0.1.7,zipp==0.6.0
py37 run-test-pre: PYTHONHASHSEED='3935109706'
py37 run-test: commands[0] | pytest -v --tb=short
============================= test session starts ==============================
platform darwin -- Python 3.7.4, pytest-5.3.1, py-1.8.0, pluggy-0.13.1 -- /Users/brian/Code/capsys-print-partials/.tox/py37/bin/python
cachedir: .tox/py37/.pytest_cache
rootdir: /Users/brian/Code/capsys-print-partials
collecting ... collected 7 items

test_capsys.py::test_write_hello PASSED                                  [ 14%]
test_capsys.py::test_print[print] PASSED                                 [ 28%]
test_capsys.py::test_print[partial] PASSED                               [ 42%]
test_capsys.py::test_print[partial_builtins] PASSED                      [ 57%]
test_capsys.py::test_print[partial_file] FAILED                          [ 71%]
test_capsys.py::test_print[partial_builtins_file] FAILED                 [ 85%]
test_capsys.py::test_print[stdout_write] PASSED                          [100%]

=================================== FAILURES ===================================
___________________________ test_print[partial_file] ___________________________
test_capsys.py:35: in test_print
    assert captured.out == "Hello\n"
E   AssertionError: assert '' == 'Hello\n'
E     + Hello
----------------------------- Captured stdout call -----------------------------
Hello
______________________ test_print[partial_builtins_file] _______________________
test_capsys.py:35: in test_print
    assert captured.out == "Hello\n"
E   AssertionError: assert '' == 'Hello\n'
E     + Hello
----------------------------- Captured stdout call -----------------------------
Hello
========================= 2 failed, 5 passed in 0.06s ==========================
ERROR: InvocationError for command /Users/brian/Code/capsys-print-partials/.tox/py37/bin/pytest -v --tb=short (exited with code 1)
___________________________________ summary ____________________________________
ERROR:   py37: commands failed

```